### PR TITLE
use split_part dbt macro instead of writing database specific code.

### DIFF
--- a/macros/parse_ga4_client_id.sql
+++ b/macros/parse_ga4_client_id.sql
@@ -4,11 +4,11 @@
 
 {% macro default__parse_ga4_client_id(client_id,extract_value) -%}
     {%- if extract_value == 'unique_id' -%}
-        {{ split_part(string_text=client_id, delimiter_text="'.'", part_number=3) }}
+        {{ dbt.split_part(string_text=client_id, delimiter_text="'.'", part_number=3) }}
     {%- elif extract_value == 'timestamp' -%}
-        {{ split_part(string_text=client_id, delimiter_text="'.'", part_number=4) }}
+        {{ dbt.split_part(string_text=client_id, delimiter_text="'.'", part_number=4) }}
     {%- elif extract_value == 'client_id' -%}
-        replace({{ client_id }}, 'GA1.2.','')
+        {{ dbt.concat([dbt.split_part(string_text=client_id, delimiter_text="'.'", part_number=3), "'.'", dbt.split_part(string_text=client_id, delimiter_text="'.'", part_number=4) ])}}
     {% else %}
     {%- set error_message = '
     Warning: the `parse_ga4_client_id` macro only accepts unique_id, timestamp, or client_id as the extract_value. The {}.{} model triggered this warning. \

--- a/macros/parse_ga4_client_id.sql
+++ b/macros/parse_ga4_client_id.sql
@@ -4,9 +4,9 @@
 
 {% macro default__parse_ga4_client_id(client_id,extract_value) -%}
     {%- if extract_value == 'unique_id' -%}
-        split_part({{ client_id }}, '.',3)
+        {{ split_part(string_text=client_id, delimiter_text="'.'", part_number=3) }}
     {%- elif extract_value == 'timestamp' -%}
-        split_part({{ client_id }}, '.',4)
+        {{ split_part(string_text=client_id, delimiter_text="'.'", part_number=4) }}
     {%- elif extract_value == 'client_id' -%}
         replace({{ client_id }}, 'GA1.2.','')
     {% else %}
@@ -16,20 +16,5 @@
 
     {%- do exceptions.raise_compiler_error(error_message) -%}
     {% endif %}
-{%- endmacro %}
-    
-{% macro bigquery__parse_ga4_client_id(client_id,extract_value) -%}
-    {%- if extract_value == 'unique_id' -%}
-        split({{ client_id }}, '.')[offset(2)]
-    {%- elif extract_value == 'timestamp' -%}
-        split({{ client_id }}, '.')[offset(3)]
-    {%- elif extract_value == 'client_id' -%}
-        replace({{ client_id }}, 'GA1.2.','')
-    {% else %}
-    {%- set error_message = '
-    Warning: the `parse_ga4_client_id` macro only accepts unique_id, timestamp, or client_id as the extract_value. The {}.{} model triggered this warning. \
-    '.format(model.package_name, model.name) -%}
+{%- endmacro %}   
 
-    {%- do exceptions.raise_compiler_error(error_message) -%}
-    {% endif %}
-{%- endmacro %}


### PR DESCRIPTION
## Use dbt native split_part cross database macro instead of writing dispatchers for bigquery
## Tested on Bigquery & Redshift