### PR TITLE
Update README.md and add error messages to is_internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ select
 
 ## is_internal ([source](macros/is_internal.sql))
 
-This macro reports whether a user is an internal user based on their email domain, email address, or IP address.  Relies on variables set in dbt_project.yml.
+This macro reports whether a user is an internal user based on their email domain, email address, or IP address.  Relies on at least one variable being set in [dbt_project.yml](https://github.com/sutrolabs/dbt_census_utils#optional-step-4-define-internal-user-variables).
 
 **Args:**
 

--- a/macros/is_internal.sql
+++ b/macros/is_internal.sql
@@ -6,9 +6,23 @@
 
     case
         when 1 = 2 then true
+        {% if email == none and ip_address == none %}
+            {%- set error_message = '
+            The `is_internal` macro was called without an email or ip_address, so it has nothing to evaluate. The {}.{} model triggered this warning. \
+            '.format(model.package_name, model.name) -%}
+            {%- do exceptions.raise_compiler_error(error_message) -%}
+        {%- endif %}
+
+        {% if var("internal_domain", none) == none and var("internal_email_relation", none) == none and var("internal_ip_relation", none) == none %}
+            {%- set error_message = '
+            The `is_internal` macro was called without an internal email domain, internal email relation, or internal ip relation defined in your dbt_project.yml, so it has nothing to compare to. The {}.{} model triggered this warning. \
+            '.format(model.package_name, model.name) -%}
+            {%- do exceptions.raise_compiler_error(error_message) -%}
+        {%- endif %}
+
         {% if email %}
             {%- set exclusion = var("internal_email_column", 'email_address') ~ ' is not null' -%}
-            {% if var("internal_email_relation", false)%}
+            {% if var("internal_email_relation", false) %}
                 {%- set internal_email = dbt_utils.get_column_values(table=ref(var("internal_email_relation")), column=var("internal_email_column", 'email_address'), where=exclusion) -%}
                 when array_contains({{ email }}::variant, {{internal_email}}) then true
             {%- endif %}
@@ -30,9 +44,23 @@
 
     case
         when 1 = 2 then true
+        {% if email == none and ip_address == none %}
+            {%- set error_message = '
+            The `is_internal` macro was called without an email or ip_address, so it has nothing to evaluate. The {}.{} model triggered this warning. \
+            '.format(model.package_name, model.name) -%}
+            {%- do exceptions.raise_compiler_error(error_message) -%}
+        {%- endif %}
+
+        {% if var("internal_domain", none) == none and var("internal_email_relation", none) == none and var("internal_ip_relation", none) == none %}
+            {%- set error_message = '
+            The `is_internal` macro was called without an internal email domain, internal email relation, or internal ip relation defined in your dbt_project.yml, so it has nothing to compare to. The {}.{} model triggered this warning. \
+            '.format(model.package_name, model.name) -%}
+            {%- do exceptions.raise_compiler_error(error_message) -%}
+        {%- endif %}
+
         {% if email %}
             {%- set exclusion = var("internal_email_column", 'email_address') ~ ' is not null' -%}
-            {% if var("internal_email_relation", false)%}
+            {% if var("internal_email_relation", false) %}
                 {%- set internal_email = dbt_utils.get_column_values(table=ref(var("internal_email_relation")), column=var("internal_email_column", 'email_address'), where=exclusion) -%}
                 when {{ email }} in unnest({{ internal_email }}) then true
             {%- endif %}
@@ -54,9 +82,23 @@
 
     case
         when 1 = 2 then true
+        {% if email == none and ip_address == none %}
+            {%- set error_message = '
+            The `is_internal` macro was called without an email or ip_address, so it has nothing to evaluate. The {}.{} model triggered this warning. \
+            '.format(model.package_name, model.name) -%}
+            {%- do exceptions.raise_compiler_error(error_message) -%}
+        {%- endif %}
+
+        {% if var("internal_domain", none) == none and var("internal_email_relation", none) == none and var("internal_ip_relation", none) == none %}
+            {%- set error_message = '
+            The `is_internal` macro was called without an internal email domain, internal email relation, or internal ip relation defined in your dbt_project.yml, so it has nothing to compare to. The {}.{} model triggered this warning. \
+            '.format(model.package_name, model.name) -%}
+            {%- do exceptions.raise_compiler_error(error_message) -%}
+        {%- endif %}
+        
         {% if email %}
             {%- set exclusion = var("internal_email_column", 'email_address') ~ ' is not null' -%}
-            {% if var("internal_email_relation", false)%}
+            {% if var("internal_email_relation", false) %}
                 {%- set internal_email = dbt_utils.get_column_values(table=ref(var("internal_email_relation")), column=var("internal_email_column", 'email_address'), where=exclusion)|join(',') -%}
                 when charindex({{ email }},'{{internal_email}}') > 0 then true
             {%- endif %}


### PR DESCRIPTION
Updates the readme.MD to be have the is_internal macro link back to internal variables step.

Adds error messages to is_internal if:
1) The macro is called without any parameters
2) The macro is called with none of the required variables being set.