### PR TITLE
Update PR template and revert version to 0.1.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,6 @@
 - [ ] Yes (please provide change details below.)
 - [ ] No  (please provide an explanation as to how the change is non-breaking below.)
 
-**Did you update the dbt_project.yml files with the version upgrade (using semantic versioning)? (In both the main project and integration_tests)** 
-<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade them both -->
-- [ ] Yes
-
 **Is this PR in response to a previously created issue**
 <!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
 - [ ] Yes [link here]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "census_utils"
-version: "0.1.1"
+version: "0.1.0"
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 models:


### PR DESCRIPTION
After some discussion, I decided to always leave the version in dbt_project.yml at 0.1.0 so that people don't have to update that every time they make a change.  We can still use Github releases to track versions.